### PR TITLE
feat: Add text editing features to notes

### DIFF
--- a/app/admin/note/MarkDown.js
+++ b/app/admin/note/MarkDown.js
@@ -11,6 +11,7 @@ const formatHTML = (text) => {
     text = text.replace(/^###\s*(.*)$/gm, "<h2>$1</h2>");
     text = text.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
     text = text.replace(/\*(.*?)\*/g, "<em>$1</em>");
+    text = text.replace(/__(.*?)__/g, "<u>$1</u>"); // Added underline support
     text = text.replace(/^\*\s?(.*)$/gm, "<li>$1</li>");
     let result = wrapListItemsWithUl(text);
     text = text

--- a/app/admin/note/addNote.js
+++ b/app/admin/note/addNote.js
@@ -17,14 +17,145 @@ import { handleSaveNewNote, handleUpdateNote } from "./handleNotes"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
-import { SquarePen, Italic, Bold, List } from "lucide-react"
+import { SquarePen, Italic, Bold, List, Underline } from "lucide-react"
 
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 export function AddNote({ icon, noteid, title, body }) {
     const router = useRouter();
-    const titleRef = useRef("")
-    const bodyRef = useRef("")
+    const titleRef = useRef(null)
+    const bodyRef = useRef(null)
+
+    const applyFormat = (formatType) => {
+        const textarea = bodyRef.current;
+        if (!textarea) return;
+
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const selectedText = textarea.value.substring(start, end);
+        const beforeText = textarea.value.substring(0, start);
+        const afterText = textarea.value.substring(end);
+        let newText = "";
+        let newStart = start;
+        let newEnd = end;
+
+        switch (formatType) {
+            case "bold":
+                newText = `${beforeText}**${selectedText}**${afterText}`;
+                newStart = start + 2;
+                newEnd = end + 2;
+                if (selectedText === "") newStart = newEnd = start + 2; // Place cursor in middle if no selection
+                break;
+            case "italic":
+                newText = `${beforeText}*${selectedText}*${afterText}`;
+                newStart = start + 1;
+                newEnd = end + 1;
+                if (selectedText === "") newStart = newEnd = start + 1;
+                break;
+            case "underline":
+                newText = `${beforeText}__${selectedText}__${afterText}`;
+                newStart = start + 2;
+                newEnd = end + 2;
+                if (selectedText === "") newStart = newEnd = start + 2;
+                break;
+            case "list": {
+                const currentFullText = textarea.value;
+                let newSelectionStart = start;
+                let newSelectionEnd = end;
+
+                // Determine the range of lines affected by the selection
+                let lineStartIndex = start;
+                while (lineStartIndex > 0 && currentFullText[lineStartIndex - 1] !== '\n') {
+                    lineStartIndex--;
+                }
+                let lineEndIndex = end;
+                // If selection ends at a newline, we don't want to extend to the next line
+                if (currentFullText[lineEndIndex] === '\n' && end > start) {
+                    // no-op, lineEndIndex is fine
+                } else {
+                    while (lineEndIndex < currentFullText.length && currentFullText[lineEndIndex] !== '\n') {
+                        lineEndIndex++;
+                    }
+                }
+                
+                const affectedText = currentFullText.substring(lineStartIndex, lineEndIndex);
+                const lines = affectedText.split('\n');
+                
+                const allLinesAreListItems = lines.every(line => line.startsWith("* ") || line.trim() === "");
+
+                let processedLines = [];
+                let textWasChanged = false;
+                let charsAdded = 0; // Track net change in characters for selection adjustment
+
+                if (allLinesAreListItems) {
+                    // Remove "* " from all lines
+                    processedLines = lines.map(line => {
+                        if (line.startsWith("* ")) {
+                            charsAdded -= 2;
+                            textWasChanged = true;
+                            return line.substring(2);
+                        }
+                        return line;
+                    });
+                } else {
+                    // Add "* " to lines that don't have it
+                    processedLines = lines.map(line => {
+                        if (line.trim() !== "" && !line.startsWith("* ")) {
+                            charsAdded += 2;
+                            textWasChanged = true;
+                            return "* " + line;
+                        }
+                        return line;
+                    });
+                }
+                
+                const newAffectedText = processedLines.join('\n');
+                newText = currentFullText.substring(0, lineStartIndex) + newAffectedText + currentFullText.substring(lineEndIndex);
+                
+                if(textWasChanged){
+                    if (start === end) { // No selection, cursor on a line
+                        // Adjust cursor based on whether we added or removed "* "
+                        if (allLinesAreListItems) { // Removed
+                             newSelectionStart = Math.max(lineStartIndex, start - 2);
+                        } else { // Added
+                             newSelectionStart = start + 2;
+                        }
+                        newSelectionEnd = newSelectionStart;
+                    } else { // Selection
+                        newSelectionStart = start; // Keep start of selection the same
+                        // The end of selection needs to be adjusted by the total change in length of the processed lines.
+                        // This is a simplified adjustment.
+                        newSelectionEnd = end + charsAdded;
+                    }
+                } else {
+                    newSelectionStart = start;
+                    newSelectionEnd = end;
+                }
+                
+                // Ensure selection doesn't go out of bounds
+                newSelectionStart = Math.max(0, Math.min(newText.length, newSelectionStart));
+                newSelectionEnd = Math.max(0, Math.min(newText.length, newSelectionEnd));
+
+                // Update newStart and newEnd for the final assignment
+                newStart = newSelectionStart;
+                newEnd = newSelectionEnd;
+                break;
+            }
+            default:
+                newText = textarea.value; // No change
+                newStart = start;
+                newEnd = end;
+        }
+
+        textarea.value = newText;
+        textarea.focus();
+        // A slight delay might be needed for the selection to apply correctly after value change
+        setTimeout(() => {
+            textarea.selectionStart = newStart;
+            textarea.selectionEnd = newEnd;
+        }, 0);
+    };
+
     const handleSave = async () => {
         await handleSaveNewNote(titleRef.current.value, bodyRef.current.value)
         // titleRef.current.value = ""
@@ -66,15 +197,16 @@ export function AddNote({ icon, noteid, title, body }) {
                     </DialogDescription>
                 </DialogHeader>
                 <div className="flex flex-col gap-4 items-end">
-                    <ToggleGroup type="multiple">
-                        <ToggleGroupItem value="bold"><Bold /></ToggleGroupItem>
-                        <ToggleGroupItem value="italic"><Italic /></ToggleGroupItem>
-                        <ToggleGroupItem value="bullet"><List /></ToggleGroupItem>
+                    <ToggleGroup type="multiple" aria-label="Text formatting">
+                        <ToggleGroupItem value="bold" aria-label="Toggle bold" onClick={() => applyFormat("bold")}><Bold /></ToggleGroupItem>
+                        <ToggleGroupItem value="italic" aria-label="Toggle italic" onClick={() => applyFormat("italic")}><Italic /></ToggleGroupItem>
+                        <ToggleGroupItem value="underline" aria-label="Toggle underline" onClick={() => applyFormat("underline")}><Underline /></ToggleGroupItem>
+                        <ToggleGroupItem value="bullet" aria-label="Toggle list" onClick={() => applyFormat("list")}><List /></ToggleGroupItem>
                     </ToggleGroup>
                 </div>
                 <div className="flex flex-col gap-4 py-4">
-                    <Input id="title" defaultValue={title} placeholder="Note title here." className="col-span-3" ref={titleRef} />
-                    <Textarea rows="10" defaultValue={body} placeholder="Your thoughts here." className="col-span-3" ref={bodyRef} />
+                    <Input id="title" defaultValue={title || ""} placeholder="Note title here." className="col-span-3" ref={titleRef} />
+                    <Textarea rows="10" defaultValue={body || ""} placeholder="Your thoughts here." className="col-span-3" ref={bodyRef} />
                 </div>
                 <DialogFooter>
                     <DialogClose asChild>


### PR DESCRIPTION
This commit introduces text formatting capabilities (Bold, Italic, Underline, List) within the note creation and editing interface.

Key changes:

- Modified `app/admin/note/addNote.js`:
    - Added an "Underline" button to the formatting toolbar.
    - Implemented logic to wrap selected text or insert markdown syntax (`**bold**`, `*italic*`, `__underline__`, `* list item`) in the textarea when formatting buttons are clicked.
    - Handles cursor placement and selection adjustment after formatting.

- Updated `app/admin/note/MarkDown.js`:
    - Modified the `formatHTML` function to correctly render text wrapped with `__text__` as underlined text (using `<u>text</u>`).

Unit tests were not added as part of this change because no pre-existing testing infrastructure was found in the project. Setting up a test framework would be a separate undertaking.